### PR TITLE
Raise exception when deprecated field is accessed

### DIFF
--- a/django_deprecate_fields/deprecate_field.py
+++ b/django_deprecate_fields/deprecate_field.py
@@ -1,9 +1,23 @@
 import sys
+import django
 
 from django.db.models import BooleanField, NullBooleanField
 
 
-def deprecate_field(field_instance, return_instead=None):
+# https://docs.djangoproject.com/en/2.1/ref/models/fields/#booleanfield
+USE_NULLBOOLEANFIELD = django.VERSION < (2, 1, 0)
+
+
+class AccessDeprecatedField(Exception):
+    """Raise exception when deprecated field is accessed"""
+
+
+def raise_exception(self):
+    """replacement for a deprecated field"""
+    raise AccessDeprecatedField("Deprecated field shouldn't be used anymore!")
+
+
+def deprecate_field(original_field, return_instead=None, forbid_access=True):
     """
     Can be used in models to delete a Field in a Backwards compatible manner.
     The process for deleting old model Fields is:
@@ -12,22 +26,27 @@ def deprecate_field(field_instance, return_instead=None):
     3. Delete the field from the model.
 
     For (1) and (3) you need to run ./manage.py makemigrations:
-    :param field_instance: The field to deprecate
+    :param original_field: The field to deprecate
     :param return_instead: A value or function that
+    :param forbid_access: raise an exception when field is accessed
     the field will pretend to have
     """
+    field_to_return = original_field
     if not set(sys.argv) & {"makemigrations", "migrate"}:
-        if not callable(return_instead):
-            return return_instead
-        return return_instead()
-    
-    if not type(field_instance) == BooleanField:
-        field_instance.null = True
-        return field_instance
-    
-    # A BooleanField does not allow null=True, so we need to cast
-    # this to a NullBooleanField
-    return NullBooleanField(
-        help_text=field_instance.help_text,
-        default=field_instance.default
-    )
+        if return_instead is None and forbid_access:
+            field_to_return = property(raise_exception)
+        elif callable(return_instead):
+            field_to_return = return_instead()
+        else:
+            field_to_return = return_instead
+    else:
+        if type(field_to_return) == BooleanField and USE_NULLBOOLEANFIELD:
+            # A BooleanField does not allow null=True, so we need to cast
+            # this to a NullBooleanField for Django < 2.1
+            field_to_return = NullBooleanField(
+                help_text=field_to_return.help_text,
+                default=field_to_return.default
+            )
+        else:
+            field_to_return.null = True
+    return field_to_return


### PR DESCRIPTION
Not sure if it matches your vision but it makes sense for me.

Here is how it looks like:
```
In [123]: MyModel().myfield
---------------------------------------------------------------------------
AccessDeprecatedField                     Traceback (most recent call last)
<ipython-input-72-d46d25d6eb90> in <module>()
----> 1 MyModel().myfield

<ipython-input-70-3dcc944f58f2> in raise_exception(self)
     16 def raise_exception(self):
     17     """replacement for deprecated field"""
---> 18     raise AccessDeprecatedField("Deprecated field shouldn't be used anymore!")
     19 
     20 

AccessDeprecatedField: Deprecated field shouldn't be used anymore!

In [123]: MyModel().myfield = 4
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-73-ad458d8e91f7> in <module>()
----> 1 MyModel().myfield = 4

AttributeError: can't set attribute
```

You might want to change `forbid_access` to `False` to keep old behavior by default.
Also, there might be better texts/names to be used.