### PR TITLE
Remove special-case for BooleanField

### DIFF
--- a/django_deprecate_fields/deprecate_field.py
+++ b/django_deprecate_fields/deprecate_field.py
@@ -53,13 +53,5 @@ def deprecate_field(field_instance, return_instead=None):
     if not set(sys.argv) & {"makemigrations", "migrate", "showmigrations"}:
         return DeprecatedField(return_instead)
 
-    if not type(field_instance) == BooleanField:
-        field_instance.null = True
-        return field_instance
-
-    # A BooleanField does not allow null=True, so we need to cast
-    # this to a NullBooleanField
-    return NullBooleanField(
-        help_text=field_instance.help_text,
-        default=field_instance.default
-    )
+    field_instance.null = True
+    return field_instance


### PR DESCRIPTION
Referencing issue #11

Since Django 2.1 [null=True is now supported in BooleanField.](https://docs.djangoproject.com/en/2.1/ref/models/fields/#django.db.models.BooleanField)