### PR TITLE
Add log warnings

### DIFF
--- a/django_deprecate_fields/deprecate_field.py
+++ b/django_deprecate_fields/deprecate_field.py
@@ -1,7 +1,8 @@
+import logging
 import sys
 import warnings
 
-from django.db.models import BooleanField, NullBooleanField
+logger = logging.getLogger(__file__)
 
 
 class DeprecatedField(object):
@@ -20,20 +21,26 @@ class DeprecatedField(object):
         for k, v in type(obj).__dict__.items():
             if v is self:
                 return k
-        return '<unknown>'
+        return "<unknown>"
 
     def __get__(self, obj, type=None):
-        warnings.warn('accessing deprecated field %s.%s' % (
-                obj.__class__.__name__, self._get_name(obj)
-            ), DeprecationWarning, stacklevel=2)
+        msg = "accessing deprecated field %s.%s" % (
+            obj.__class__.__name__,
+            self._get_name(obj),
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        logger.warning(msg)
         if not callable(self.val):
             return self.val
         return self.val()
 
     def __set__(self, obj, val):
-        warnings.warn('writing to deprecated field %s.%s' % (
-                obj.__class__.__name__, self._get_name(obj)
-            ), DeprecationWarning, stacklevel=2)
+        msg = "writing to deprecated field %s.%s" % (
+            obj.__class__.__name__,
+            self._get_name(obj),
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        logger.warning(msg)
         self.val = val
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,50 +14,44 @@
 
 from codecs import open
 from os import path
-from setuptools import setup, find_packages
 
+from setuptools import setup
 
 PROJECT_DIR = path.abspath(path.dirname(__file__))
 
-long_description = open('README.md').read()
+long_description = open("README.md").read()
 
-install_requirements = [
-    'Django>=2.1'
-]
+install_requirements = ["Django>=2.1"]
 
 setup(
-    name='django-deprecate-fields',
-    version='0.1.0',
-
-    description='This package allows deprecating model fields and allows '
-                'removing them in a backwards compatible manner.',
+    name="django-deprecate-fields",
+    version="0.1.0",
+    description="This package allows deprecating model fields and allows "
+    "removing them in a backwards compatible manner.",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/3YOURMIND/django-deprecate-fields',
-    author='3YOURMIND GmbH',
-    license='Apache License 2.0',
-
-    packages=['django_deprecate_fields'],
+    long_description_content_type="text/markdown",
+    url="https://github.com/3YOURMIND/django-deprecate-fields",
+    author="3YOURMIND GmbH",
+    license="Apache License 2.0",
+    packages=["django_deprecate_fields"],
     install_requires=install_requirements,
-
-    keywords='django migration deprecation database backward compatibility',
+    keywords="django migration deprecation database backward compatibility",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'Environment :: Web Environment',
-        'Framework :: Django',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
-        'Framework :: Django :: 3.1',
-
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-    ]
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
+        "Framework :: Django :: 3.0",
+        "Framework :: Django :: 3.1",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
 )


### PR DESCRIPTION
### Summary

This PR adds the log messages for the deprecated fields access.
There were only messages generated by the `warnings` package which are not logged for instances that collect logs. 

### Changes

- [x] Adds `logger.warning()`
- [x] Checks with Black, Flake8 and isort
