### PR TITLE
fix(25): logger is instantiated with __name__ instead of __file__

### DIFF
--- a/django_deprecate_fields/deprecate_field.py
+++ b/django_deprecate_fields/deprecate_field.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import warnings
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class DeprecatedField(object):


### PR DESCRIPTION
as per https://github.com/3YOURMIND/django-deprecate-fields/issues/25