### PR TITLE
Add capability to specify commands that will return the actual field and not DeprecatedField

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ in your code will return `None` (or optionally any value or callable passed to `
 Lastly, after the changes above have been deployed, `field1` can then safely be removed in the model (plus another
 `makemigrations` run)
 
+### Custom django commands
+
+If you need the actual field to be returned when a django command other than `makemigrations`, `migrate` or `showmigrations` is run, you can use the
+`commands_requiring_concrete_class` parameter.
+
+For instance if you generate migrations with `pgmakemigrations` instead of `makemigrations`, you can create the field
+this way
+```python
+    deprecate_field(models.CharField(), commands_requiring_concrete_class={"pgmakemigrations"})
+```
+
 ## Contributing
 
 First of all, thank you very much for contributing to this project. Please base

--- a/django_deprecate_fields/deprecate_field.py
+++ b/django_deprecate_fields/deprecate_field.py
@@ -55,7 +55,7 @@ class DeprecatedField(object):
         self.val = val
 
 
-def deprecate_field(field_instance, return_instead=None, raise_on_access=False):
+def deprecate_field(field_instance, return_instead=None, raise_on_access=False, commands_requiring_concrete_class=None):
     """
     Can be used in models to delete a Field in a Backwards compatible manner.
     The process for deleting old model Fields is:
@@ -68,8 +68,13 @@ def deprecate_field(field_instance, return_instead=None, raise_on_access=False):
     :param return_instead: A value or function that
     the field will pretend to have
     :param raise_on_access: If true, raise FieldDeprecated instead of logging a warning
+    :param commands_requiring_concrete_class: A set of commands that need the actual field
     """
-    if not set(sys.argv) & {"makemigrations", "migrate", "showmigrations"}:
+    base_django_migration_commands = {"makemigrations", "migrate", "showmigrations"}
+    exhaustive_commands = base_django_migration_commands | (
+            commands_requiring_concrete_class or set()
+    )
+    if not set(sys.argv) & exhaustive_commands:
         return DeprecatedField(return_instead, raise_on_access=raise_on_access)
 
     field_instance.null = True


### PR DESCRIPTION
Hello,

I am using [django-postgres-extra](https://github.com/SectorLabs/django-postgres-extra) in a project. This implies using a custom django command to generate migrations. This is kind of blocking with the current implem of this library because the list of command bound to real implem return is hardcoded.
I thought that it could be useful to allow specifying custom commands that will trigger real implem return.

Tell me how you feel about this.

Thanks