### PR TITLE
Support django-postgres-extra pgmakemigrations

### DIFF
--- a/django_deprecate_fields/deprecate_field.py
+++ b/django_deprecate_fields/deprecate_field.py
@@ -69,7 +69,7 @@ def deprecate_field(field_instance, return_instead=None, raise_on_access=False):
     the field will pretend to have
     :param raise_on_access: If true, raise FieldDeprecated instead of logging a warning
     """
-    if not set(sys.argv) & {"makemigrations", "migrate", "showmigrations"}:
+    if not set(sys.argv) & {"makemigrations", "migrate", "pgmakemigrations", "showmigrations"}:
         return DeprecatedField(return_instead, raise_on_access=raise_on_access)
 
     field_instance.null = True


### PR DESCRIPTION
I currently use `django-postgres-extra` for its table partitioning support. This usage requires us to use `pgmakemigrations` to generate a migration. https://django-postgres-extra.readthedocs.io/en/latest/table_partitioning.html#generating-a-migration

The current behavior of this library attempts to remove any `deprecate_field` usage when running `pgmakemigrations`. Adding this command to this set allows usage of `deprecate_field` and partitioned tables