### PR TITLE
Add support for custom migration commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ in your code will return `None` (or optionally any value or callable passed to `
 Lastly, after the changes above have been deployed, `field1` can then safely be removed in the model (plus another
 `makemigrations` run)
 
+### Custom django commands
+
+If you need the actual field to be returned when a django command other 
+than `makemigrations`, `migrate` or `showmigrations` is run, you can specify the 
+`DEPRECATE_FIELD_CUSTOM_MIGRATION_COMMAND` parameter in the settings.
+
+For instance if you generate migrations with `pgmakemigrations` instead of `makemigrations`, 
+you can add this to your settings:
+```python
+DEPRECATE_FIELD_CUSTOM_MIGRATION_COMMAND = {"pgmakemigrations"}
+```
+
+
 ## Contributing
 
 First of all, thank you very much for contributing to this project. Please base

--- a/django_deprecate_fields/deprecate_field.py
+++ b/django_deprecate_fields/deprecate_field.py
@@ -2,6 +2,8 @@ import logging
 import sys
 import warnings
 
+from django.conf import settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -69,7 +71,11 @@ def deprecate_field(field_instance, return_instead=None, raise_on_access=False):
     the field will pretend to have
     :param raise_on_access: If true, raise FieldDeprecated instead of logging a warning
     """
-    if not set(sys.argv) & {"makemigrations", "migrate", "showmigrations"}:
+
+    base_migration_commands = {"makemigrations", "migrate", "showmigrations"}
+    custom_migration_commands = getattr(settings, "DEPRECATE_FIELD_CUSTOM_MIGRATION_COMMAND", set())
+
+    if not set(sys.argv) & base_migration_commands | custom_migration_commands:
         return DeprecatedField(return_instead, raise_on_access=raise_on_access)
 
     field_instance.null = True


### PR DESCRIPTION
This will enable deprecate_field() to work if custom migration commands are beeing used (e.g. pgmakemigrations)

This solves those 2 PRs in a different way:
https://github.com/3YOURMIND/django-deprecate-fields/pull/33
https://github.com/3YOURMIND/django-deprecate-fields/pull/30